### PR TITLE
Align VPC3+S register map and fix debug logging

### DIFF
--- a/Core/Src/main.c
+++ b/Core/Src/main.c
@@ -20,11 +20,11 @@
 
 /* Includes ------------------------------------------------------------------*/
 #include "main.h"
-#include "stm32f4xx_hal.h"
-#include "platform.h"
 #include "DpAppl.h"
 #include "DpCfg.h"
 #include "dp_if.h"
+#include "platform.h"
+#include "stm32f4xx_hal.h"
 #include <stdio.h>
 #include <string.h>
 
@@ -72,10 +72,9 @@ void print_vpc3_state(void);
 #define PUTCHAR_PROTOTYPE int fputc(int ch, FILE *f)
 #endif
 
-PUTCHAR_PROTOTYPE
-{
-    HAL_UART_Transmit(&huart2, (uint8_t *)&ch, 1, HAL_MAX_DELAY);
-	return ch;
+PUTCHAR_PROTOTYPE {
+  HAL_UART_Transmit(&huart2, (uint8_t *)&ch, 1, HAL_MAX_DELAY);
+  return ch;
 }
 
 /* USER CODE END 0 */
@@ -84,210 +83,220 @@ PUTCHAR_PROTOTYPE
   * @brief  The application entry point.
   * @retval int
   */
-int main(void)
-{
-	/* USER CODE BEGIN 1 */
-	/* USER CODE END 1 */
+int main(void) {
+  /* USER CODE BEGIN 1 */
+  /* USER CODE END 1 */
 
-	/* MCU Configuration--------------------------------------------------------*/
+  /* MCU Configuration--------------------------------------------------------*/
 
-	/* Reset of all peripherals, Initializes the Flash interface and the Systick. */
-	HAL_Init();
+  /* Reset of all peripherals, Initializes the Flash interface and the Systick.
+   */
+  HAL_Init();
 
-	/* USER CODE BEGIN Init */
-	/* USER CODE END Init */
+  /* USER CODE BEGIN Init */
+  /* USER CODE END Init */
 
-	/* Configure the system clock */
-	SystemClock_Config();
+  /* Configure the system clock */
+  SystemClock_Config();
 
-	/* USER CODE BEGIN SysInit */
-	/* USER CODE END SysInit */
+  /* USER CODE BEGIN SysInit */
+  /* USER CODE END SysInit */
 
-	/* Initialize all configured peripherals */
-	MX_GPIO_Init();
+  /* Initialize all configured peripherals */
+  MX_GPIO_Init();
   MX_USART2_UART_Init();
-	MX_SPI1_Init();
+  MX_SPI1_Init();
 
-	/* USER CODE BEGIN 2 */
-    
-    printf("\r\n");
-    printf("==============================================================================\r\n");
-    printf("    VPC3+S PROFIBUS Slave - Standard Initialization Approach\r\n");
-    printf("==============================================================================\r\n");
-    printf("\r\n");
-    printf("Using standard DpAppl_ProfibusInit() for complete initialization\r\n");
-    printf("\r\n");
+  /* USER CODE BEGIN 2 */
 
-    // Perform hardware reset of VPC3+S before initialization
-    printf("Performing VPC3+S hardware reset...\r\n");
-    HAL_GPIO_WritePin(VPC3_RESET_PORT, VPC3_RESET_PIN, GPIO_PIN_RESET);  // Assert reset
-    HAL_Delay(10);                                                       // Hold reset for 10ms
-    HAL_GPIO_WritePin(VPC3_RESET_PORT, VPC3_RESET_PIN, GPIO_PIN_SET);   // Release reset
-    HAL_Delay(50);                                                       // Wait longer for chip to stabilize
-    printf("Hardware reset completed.\r\n");
-    
-    // Check initial VPC3+ status after hardware reset
-    printf("Reading initial VPC3+ status...\r\n");
-    extern uint8_t Vpc3Read(uint16_t address);
-    extern void Vpc3Write(uint16_t address, uint8_t data);
-    
-    uint8_t status_lo_initial = Vpc3Read(0x04);
-    uint8_t status_hi_initial = Vpc3Read(0x05);
-    printf("Status Register (hi,low): 0x%02X%02X\r\n", status_hi_initial, status_lo_initial);
-    printf("\r\n");
-    
-    // Force VPC3+ to OFFLINE state before initialization
-    printf("Forcing VPC3+ to OFFLINE state...\r\n");
-    uint8_t status_before = Vpc3Read(0x04);
-    printf("Status before GO_OFFLINE: 0x%02X\r\n", status_before);
-    
-    // Send GO_OFFLINE command
-    Vpc3Write(0x08, 0x04);  // VPC3_GO_OFFLINE command
-    HAL_Delay(20);          // Wait for command to take effect
-    
-    uint8_t status_after = Vpc3Read(0x04);
-    printf("Status after GO_OFFLINE: 0x%02X\r\n", status_after);
-    
-    if (status_after & 0x01) {
-        printf("WARNING: VPC3+ still not in OFFLINE state, trying again...\r\n");
-        // Try a different approach - send RESET command first
-        Vpc3Write(0x08, 0x02);  // VPC3_RESET command
-        HAL_Delay(50);
-        Vpc3Write(0x08, 0x04);  // VPC3_GO_OFFLINE command
-        HAL_Delay(20);
-        
-        status_after = Vpc3Read(0x04);
-        printf("Status after RESET+GO_OFFLINE: 0x%02X\r\n", status_after);
+  printf("\r\n");
+  printf("====================================================================="
+         "=========\r\n");
+  printf("    VPC3+S PROFIBUS Slave - Standard Initialization Approach\r\n");
+  printf("====================================================================="
+         "=========\r\n");
+  printf("\r\n");
+  printf(
+      "Using standard DpAppl_ProfibusInit() for complete initialization\r\n");
+  printf("\r\n");
+
+  // Perform hardware reset of VPC3+S before initialization
+  printf("Performing VPC3+S hardware reset...\r\n");
+  HAL_GPIO_WritePin(VPC3_RESET_PORT, VPC3_RESET_PIN,
+                    GPIO_PIN_RESET); // Assert reset
+  HAL_Delay(10);                     // Hold reset for 10ms
+  HAL_GPIO_WritePin(VPC3_RESET_PORT, VPC3_RESET_PIN,
+                    GPIO_PIN_SET); // Release reset
+  HAL_Delay(50);                   // Wait longer for chip to stabilize
+  printf("Hardware reset completed.\r\n");
+
+  // Check initial VPC3+ status after hardware reset
+  printf("Reading initial VPC3+ status...\r\n");
+  extern uint8_t Vpc3Read(uint16_t address);
+  extern void Vpc3Write(uint16_t address, uint8_t data);
+
+  uint8_t status_lo_initial = Vpc3Read(0x04);
+  uint8_t status_hi_initial = Vpc3Read(0x05);
+  printf("Status Register (hi,low): 0x%02X%02X\r\n", status_hi_initial,
+         status_lo_initial);
+  printf("\r\n");
+
+  // Force VPC3+ to OFFLINE state before initialization
+  printf("Forcing VPC3+ to OFFLINE state...\r\n");
+  uint8_t status_before = Vpc3Read(0x04);
+  printf("Status before GO_OFFLINE: 0x%02X\r\n", status_before);
+
+  // Send GO_OFFLINE command
+  Vpc3Write(0x08, 0x04); // VPC3_GO_OFFLINE command
+  HAL_Delay(20);         // Wait for command to take effect
+
+  uint8_t status_after = Vpc3Read(0x04);
+  printf("Status after GO_OFFLINE: 0x%02X\r\n", status_after);
+
+  if (status_after & 0x01) {
+    printf("WARNING: VPC3+ still not in OFFLINE state, trying again...\r\n");
+    // Try a different approach - send RESET command first
+    Vpc3Write(0x08, 0x02); // VPC3_RESET command
+    HAL_Delay(50);
+    Vpc3Write(0x08, 0x04); // VPC3_GO_OFFLINE command
+    HAL_Delay(20);
+
+    status_after = Vpc3Read(0x04);
+    printf("Status after RESET+GO_OFFLINE: 0x%02X\r\n", status_after);
+  }
+
+  if (!(status_after & 0x01)) {
+    printf("SUCCESS: VPC3+ is now in OFFLINE state\r\n");
+  }
+  printf("\r\n");
+
+  // Initialize PROFIBUS using the standard approach
+  // This function handles all the required initialization steps:
+  // - DpPrm_Init()    - Parameter handling initialization
+  // - DpCfg_Init()    - Configuration handling initialization
+  // - DpDiag_Init()   - Diagnostics initialization
+  // - VPC3_MemoryTest() - Memory verification
+  // - VPC3_Initialization() - VPC3 chip initialization
+  // - VPC3_Start()    - Start the VPC3 chip
+
+  printf("Initializing PROFIBUS with configuration:\r\n");
+  print_vpc3_registers();
+  printf("  - Slave Address: %d (0x%02X)\r\n", DP_ADDR, DP_ADDR);
+  printf("  - Ident Number:  0x%04X\r\n", IDENT_NR);
+  printf("  - GSD File:      Profibus.gsd\r\n");
+  printf("\r\n");
+
+  DpAppl_ProfibusInit();
+  printf("PROFIBUS initialization completed successfully!\r\n");
+  printf("\r\n");
+
+  // Fuerza la activación del buffer de diagnóstico
+  // printf("DEBUG: Llamando a DpDiag_ResetDiagnosticBuffer() para forzar
+  // diagnóstico inicial...\r\n"); extern void
+  // DpDiag_ResetDiagnosticBuffer(void); DpDiag_ResetDiagnosticBuffer();
+  // printf("DEBUG: DpDiag_ResetDiagnosticBuffer() llamada.\r\n");
+
+  HAL_Delay(2000); // Wait for command to take effect and stabilize VPC3+
+  // Check final VPC3+ status after complete initialization
+  printf("Reading final VPC3+ status...\r\n");
+  print_vpc3_registers();
+  uint8_t status_lo_final = Vpc3Read(0x04);
+  uint8_t status_hi_final = Vpc3Read(0x05);
+  printf("Status Register (hi,low): 0x%02X%02X\r\n", status_hi_final,
+         status_lo_final);
+  printf("\r\n");
+
+  printf("Entering main operation loop...\r\n");
+  printf("The PROFIBUS slave is now ready for master communication.\r\n");
+  printf("\r\n");
+  printf("================= PLC CONFIGURATION REQUIRED =================\r\n");
+  printf("1. Load GSD file:     Profibus.gsd\r\n");
+  printf("2. Set slave address: %d (0x%02X)\r\n", DP_ADDR, DP_ADDR);
+  printf("3. Connect PROFIBUS cable and activate communication\r\n");
+  printf(
+      "================================================================\r\n");
+  printf("\r\n");
+
+  /* USER CODE END 2 */
+
+  /* Infinite loop */
+  /* USER CODE BEGIN WHILE */
+  uint32_t last_heartbeat = 0;
+  uint32_t last_debug = 0;
+
+  // State machine for application-level status tracking
+  enum AppState { APP_WAITING_CFG, APP_IN_DATA_EX };
+  static enum AppState app_state = APP_WAITING_CFG;
+
+  while (1) {
+    /* USER CODE END WHILE */
+
+    /* USER CODE BEGIN 3 */
+
+    // Process PROFIBUS communication
+    DpAppl_ProfibusMain();
+    HAL_Delay(1);
+
+    // Check PROFIBUS state from VPC3+
+    uint8_t current_status_l = Vpc3Read(0x04);
+    // Note: MASK_DP_STATE and DATA_EX come from dp_if.h
+    // The state is in bits 6 and 5 of STATUS_L
+    uint8_t dp_state = (current_status_l & MASK_DP_STATE) >> 5;
+
+    // --- Application State Machine ---
+    if (app_state == APP_WAITING_CFG && dp_state == DATA_EX) {
+      printf("\r\n[APP_STATE_CHANGE] Entered DATA_EXCHANGE mode.\r\n\r\n");
+      app_state = APP_IN_DATA_EX;
+    } else if (app_state == APP_IN_DATA_EX && dp_state != DATA_EX) {
+      printf("\r\n[APP_STATE_CHANGE] WARNING: Left DATA_EXCHANGE "
+             "unexpectedly!\r\n");
+      printf("                     STATUS_L is now 0x%02X, DP_STATE is %d.\r\n",
+             current_status_l, dp_state);
+      printf("                     Returning to wait for new "
+             "configuration.\r\n\r\n");
+      app_state = APP_WAITING_CFG;
     }
-    
-    if (!(status_after & 0x01)) {
-        printf("SUCCESS: VPC3+ is now in OFFLINE state\r\n");
+
+    // Detailed log every 5 seconds
+    if (HAL_GetTick() - last_debug > 5000) {
+      print_vpc3_registers();
+      printf("==============================================\r\n");
+      print_vpc3_state();
+      printf("==============================================\r\n");
+      last_debug = HAL_GetTick();
     }
-    printf("\r\n");
 
-    // Initialize PROFIBUS using the standard approach
-    // This function handles all the required initialization steps:
-    // - DpPrm_Init()    - Parameter handling initialization  
-    // - DpCfg_Init()    - Configuration handling initialization
-    // - DpDiag_Init()   - Diagnostics initialization
-    // - VPC3_MemoryTest() - Memory verification
-    // - VPC3_Initialization() - VPC3 chip initialization
-    // - VPC3_Start()    - Start the VPC3 chip
-    
-    printf("Initializing PROFIBUS with configuration:\r\n");
-	print_vpc3_registers();
-    printf("  - Slave Address: %d (0x%02X)\r\n", DP_ADDR, DP_ADDR);
-    printf("  - Ident Number:  0x%04X\r\n", IDENT_NR);
-    printf("  - GSD File:      Profibus.gsd\r\n");
-    printf("\r\n");
-    
-    DpAppl_ProfibusInit();
-    printf("PROFIBUS initialization completed successfully!\r\n");
-    printf("\r\n");
-
-    // Fuerza la activación del buffer de diagnóstico
-    // printf("DEBUG: Llamando a DpDiag_ResetDiagnosticBuffer() para forzar diagnóstico inicial...\r\n");
-    // extern void DpDiag_ResetDiagnosticBuffer(void);
-    // DpDiag_ResetDiagnosticBuffer();
-    // printf("DEBUG: DpDiag_ResetDiagnosticBuffer() llamada.\r\n");
-    
-    HAL_Delay(2000);          // Wait for command to take effect and stabilize VPC3+
-    // Check final VPC3+ status after complete initialization
-    printf("Reading final VPC3+ status...\r\n");
-	print_vpc3_registers();
-    uint8_t status_lo_final = Vpc3Read(0x04);
-    uint8_t status_hi_final = Vpc3Read(0x05);
-    printf("Status Register (hi,low): 0x%02X%02X\r\n", status_hi_final, status_lo_final);
-    printf("\r\n");
-    
-    printf("Entering main operation loop...\r\n");
-    printf("The PROFIBUS slave is now ready for master communication.\r\n");
-    printf("\r\n");
-    printf("================= PLC CONFIGURATION REQUIRED =================\r\n");
-    printf("1. Load GSD file:     Profibus.gsd\r\n");
-    printf("2. Set slave address: %d (0x%02X)\r\n", DP_ADDR, DP_ADDR);
-    printf("3. Connect PROFIBUS cable and activate communication\r\n");
-    printf("================================================================\r\n");
-    printf("\r\n");
-
-    /* USER CODE END 2 */
-
-    /* Infinite loop */
-    /* USER CODE BEGIN WHILE */
-    	uint32_t last_heartbeat = 0;
-    uint32_t last_debug = 0;
-
-    // State machine for application-level status tracking
-    enum AppState { APP_WAITING_CFG, APP_IN_DATA_EX };
-    static enum AppState app_state = APP_WAITING_CFG;
-
-	while (1)
-	{
-		/* USER CODE END WHILE */
-
-		/* USER CODE BEGIN 3 */
-
-        // Process PROFIBUS communication
-        DpAppl_ProfibusMain();
-        HAL_Delay(1);
-
-        // Check PROFIBUS state from VPC3+
-        uint8_t current_status_l = Vpc3Read(0x04);
-        // Note: MASK_DP_STATE and DATA_EX come from dp_if.h
-        // The state is in bits 6 and 5 of STATUS_L
-        uint8_t dp_state = (current_status_l & MASK_DP_STATE) >> 5;
-
-        // --- Application State Machine ---
-        if (app_state == APP_WAITING_CFG && dp_state == DATA_EX) {
-            printf("\r\n[APP_STATE_CHANGE] Entered DATA_EXCHANGE mode.\r\n\r\n");
-            app_state = APP_IN_DATA_EX;
-        } else if (app_state == APP_IN_DATA_EX && dp_state != DATA_EX) {
-            printf("\r\n[APP_STATE_CHANGE] WARNING: Left DATA_EXCHANGE unexpectedly!\r\n");
-            printf("                     STATUS_L is now 0x%02X, DP_STATE is %d.\r\n", current_status_l, dp_state);
-            printf("                     Returning to wait for new configuration.\r\n\r\n");
-            app_state = APP_WAITING_CFG;
-        }
-
-        // Detailed log every 5 seconds
-        if (HAL_GetTick() - last_debug > 5000) {
-            print_vpc3_registers();
-            printf("==============================================\r\n");
-            print_vpc3_state();
-            printf("==============================================\r\n");
-            last_debug = HAL_GetTick();
-        }
-
-        // Heartbeat every 2 seconds
-        if (HAL_GetTick() - last_heartbeat > 2000) {
-            printf("[HEARTBEAT] El sistema está vivo. STATUS_L: 0x%02X\r\n", current_status_l);
-            if (app_state == APP_WAITING_CFG) {
-                printf("[INFO] State: Waiting for Chk_Cfg from master...\r\n");
-            } else {
-                printf("[INFO] State: DATA_EXCHANGE active.\r\n");
-            }
-            last_heartbeat = HAL_GetTick();
-        }
-	}
-	/* USER CODE END 3 */
+    // Heartbeat every 2 seconds
+    if (HAL_GetTick() - last_heartbeat > 2000) {
+      printf("[HEARTBEAT] El sistema está vivo. STATUS_L: 0x%02X\r\n",
+             current_status_l);
+      if (app_state == APP_WAITING_CFG) {
+        printf("[INFO] State: Waiting for Chk_Cfg from master...\r\n");
+      } else {
+        printf("[INFO] State: DATA_EXCHANGE active.\r\n");
+      }
+      last_heartbeat = HAL_GetTick();
+    }
+  }
+  /* USER CODE END 3 */
 }
 
 /**
   * @brief System Clock Configuration
   * @retval None
   */
-void SystemClock_Config(void)
-{
+void SystemClock_Config(void) {
   RCC_OscInitTypeDef RCC_OscInitStruct = {0};
   RCC_ClkInitTypeDef RCC_ClkInitStruct = {0};
 
   /** Configure the main internal regulator output voltage
-  */
+   */
   __HAL_RCC_PWR_CLK_ENABLE();
-    __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE2);
+  __HAL_PWR_VOLTAGESCALING_CONFIG(PWR_REGULATOR_VOLTAGE_SCALE2);
 
   /** Initializes the RCC Oscillators according to the specified parameters
-  * in the RCC_OscInitTypeDef structure.
-  */
+   * in the RCC_OscInitTypeDef structure.
+   */
   RCC_OscInitStruct.OscillatorType = RCC_OSCILLATORTYPE_HSI;
   RCC_OscInitStruct.HSIState = RCC_HSI_ON;
   RCC_OscInitStruct.HSICalibrationValue = RCC_HSICALIBRATION_DEFAULT;
@@ -296,34 +305,31 @@ void SystemClock_Config(void)
   RCC_OscInitStruct.PLL.PLLM = 16;
   RCC_OscInitStruct.PLL.PLLN = 336;
   RCC_OscInitStruct.PLL.PLLP = RCC_PLLP_DIV4;
-    RCC_OscInitStruct.PLL.PLLQ = 7;
-  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK)
-  {
+  RCC_OscInitStruct.PLL.PLLQ = 7;
+  if (HAL_RCC_OscConfig(&RCC_OscInitStruct) != HAL_OK) {
     Error_Handler();
   }
 
   /** Initializes the CPU, AHB and APB buses clocks
-  */
-  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK|RCC_CLOCKTYPE_SYSCLK
-                              |RCC_CLOCKTYPE_PCLK1|RCC_CLOCKTYPE_PCLK2;
+   */
+  RCC_ClkInitStruct.ClockType = RCC_CLOCKTYPE_HCLK | RCC_CLOCKTYPE_SYSCLK |
+                                RCC_CLOCKTYPE_PCLK1 | RCC_CLOCKTYPE_PCLK2;
   RCC_ClkInitStruct.SYSCLKSource = RCC_SYSCLKSOURCE_PLLCLK;
   RCC_ClkInitStruct.AHBCLKDivider = RCC_SYSCLK_DIV1;
   RCC_ClkInitStruct.APB1CLKDivider = RCC_HCLK_DIV2;
   RCC_ClkInitStruct.APB2CLKDivider = RCC_HCLK_DIV1;
 
-  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_2) != HAL_OK)
-  {
+  if (HAL_RCC_ClockConfig(&RCC_ClkInitStruct, FLASH_LATENCY_2) != HAL_OK) {
     Error_Handler();
   }
 }
 
 /**
-  * @brief SPI1 Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_SPI1_Init(void)
-{
+ * @brief SPI1 Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_SPI1_Init(void) {
   /* USER CODE BEGIN SPI1_Init 0 */
   /* USER CODE END SPI1_Init 0 */
 
@@ -337,13 +343,13 @@ static void MX_SPI1_Init(void)
   hspi1.Init.CLKPolarity = SPI_POLARITY_LOW;
   hspi1.Init.CLKPhase = SPI_PHASE_1EDGE;
   hspi1.Init.NSS = SPI_NSS_SOFT;
-  hspi1.Init.BaudRatePrescaler = SPI_BAUDRATEPRESCALER_256;  // Slower for better reliability
+  hspi1.Init.BaudRatePrescaler =
+      SPI_BAUDRATEPRESCALER_256; // Slower for better reliability
   hspi1.Init.FirstBit = SPI_FIRSTBIT_MSB;
   hspi1.Init.TIMode = SPI_TIMODE_DISABLE;
   hspi1.Init.CRCCalculation = SPI_CRCCALCULATION_DISABLE;
   hspi1.Init.CRCPolynomial = 10;
-  if (HAL_SPI_Init(&hspi1) != HAL_OK)
-  {
+  if (HAL_SPI_Init(&hspi1) != HAL_OK) {
     Error_Handler();
   }
   /* USER CODE BEGIN SPI1_Init 2 */
@@ -351,12 +357,11 @@ static void MX_SPI1_Init(void)
 }
 
 /**
-  * @brief USART2 Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_USART2_UART_Init(void)
-{
+ * @brief USART2 Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_USART2_UART_Init(void) {
   /* USER CODE BEGIN USART2_Init 0 */
   /* USER CODE END USART2_Init 0 */
 
@@ -370,8 +375,7 @@ static void MX_USART2_UART_Init(void)
   huart2.Init.Mode = UART_MODE_TX_RX;
   huart2.Init.HwFlowCtl = UART_HWCONTROL_NONE;
   huart2.Init.OverSampling = UART_OVERSAMPLING_16;
-  if (HAL_UART_Init(&huart2) != HAL_OK)
-  {
+  if (HAL_UART_Init(&huart2) != HAL_OK) {
     Error_Handler();
   }
   /* USER CODE BEGIN USART2_Init 2 */
@@ -379,12 +383,11 @@ static void MX_USART2_UART_Init(void)
 }
 
 /**
-  * @brief GPIO Initialization Function
-  * @param None
-  * @retval None
-  */
-static void MX_GPIO_Init(void)
-{
+ * @brief GPIO Initialization Function
+ * @param None
+ * @retval None
+ */
+static void MX_GPIO_Init(void) {
   GPIO_InitTypeDef GPIO_InitStruct = {0};
 
   /* GPIO Ports Clock Enable */
@@ -393,54 +396,54 @@ static void MX_GPIO_Init(void)
   __HAL_RCC_GPIOA_CLK_ENABLE();
   __HAL_RCC_GPIOB_CLK_ENABLE();
 
-    /*Configure GPIO pin Output Level - VPC3 CS and RESET pins */
-    HAL_GPIO_WritePin(VPC3_CS_PORT, VPC3_CS_PIN, GPIO_PIN_SET);     // CS inactive (high)
-    HAL_GPIO_WritePin(VPC3_RESET_PORT, VPC3_RESET_PIN, GPIO_PIN_SET); // RESET inactive (high)
+  /*Configure GPIO pin Output Level - VPC3 CS and RESET pins */
+  HAL_GPIO_WritePin(VPC3_CS_PORT, VPC3_CS_PIN,
+                    GPIO_PIN_SET); // CS inactive (high)
+  HAL_GPIO_WritePin(VPC3_RESET_PORT, VPC3_RESET_PIN,
+                    GPIO_PIN_SET); // RESET inactive (high)
 
-    /*Configure GPIO pin : VPC3_CS_PIN */
-    GPIO_InitStruct.Pin = VPC3_CS_PIN;
-    GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
-    GPIO_InitStruct.Pull = GPIO_NOPULL;
-    GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-    HAL_GPIO_Init(VPC3_CS_PORT, &GPIO_InitStruct);
-
-    /*Configure GPIO pin : VPC3_RESET_PIN */
-    GPIO_InitStruct.Pin = VPC3_RESET_PIN;
+  /*Configure GPIO pin : VPC3_CS_PIN */
+  GPIO_InitStruct.Pin = VPC3_CS_PIN;
   GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
   GPIO_InitStruct.Pull = GPIO_NOPULL;
   GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
-    HAL_GPIO_Init(VPC3_RESET_PORT, &GPIO_InitStruct);
+  HAL_GPIO_Init(VPC3_CS_PORT, &GPIO_InitStruct);
 
-    /*Configure GPIO pin : VPC3_INT_PIN */
-    GPIO_InitStruct.Pin = VPC3_INT_PIN;
-    GPIO_InitStruct.Mode = GPIO_MODE_IT_FALLING;
-    GPIO_InitStruct.Pull = GPIO_PULLUP;
-    HAL_GPIO_Init(VPC3_INT_PORT, &GPIO_InitStruct);
+  /*Configure GPIO pin : VPC3_RESET_PIN */
+  GPIO_InitStruct.Pin = VPC3_RESET_PIN;
+  GPIO_InitStruct.Mode = GPIO_MODE_OUTPUT_PP;
+  GPIO_InitStruct.Pull = GPIO_NOPULL;
+  GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_LOW;
+  HAL_GPIO_Init(VPC3_RESET_PORT, &GPIO_InitStruct);
+
+  /*Configure GPIO pin : VPC3_INT_PIN */
+  GPIO_InitStruct.Pin = VPC3_INT_PIN;
+  GPIO_InitStruct.Mode = GPIO_MODE_IT_FALLING;
+  GPIO_InitStruct.Pull = GPIO_PULLUP;
+  HAL_GPIO_Init(VPC3_INT_PORT, &GPIO_InitStruct);
 
   /* EXTI interrupt init*/
-    HAL_NVIC_SetPriority(EXTI9_5_IRQn, 0, 0);
-    HAL_NVIC_EnableIRQ(EXTI9_5_IRQn);
+  HAL_NVIC_SetPriority(EXTI9_5_IRQn, 0, 0);
+  HAL_NVIC_EnableIRQ(EXTI9_5_IRQn);
 }
 
 /* USER CODE BEGIN 4 */
 /* USER CODE END 4 */
 
 /**
-  * @brief  This function is executed in case of error occurrence.
-  * @retval None
-  */
-void Error_Handler(void)
-{
+ * @brief  This function is executed in case of error occurrence.
+ * @retval None
+ */
+void Error_Handler(void) {
   /* USER CODE BEGIN Error_Handler_Debug */
   /* User can add his own implementation to report the HAL error return state */
   __disable_irq();
-  while (1)
-  {
+  while (1) {
   }
   /* USER CODE END Error_Handler_Debug */
 }
 
-#ifdef  USE_FULL_ASSERT
+#ifdef USE_FULL_ASSERT
 /**
   * @brief  Reports the name of the source file and the source line number
   *         where the assert_param error has occurred.
@@ -448,69 +451,76 @@ void Error_Handler(void)
   * @param  line: assert_param error line source number
   * @retval None
   */
-void assert_failed(uint8_t *file, uint32_t line)
-{
-  /* USER CODE BEGIN 6 */
-  /* User can add his own implementation to report the file name and line number,
-     ex: printf("Wrong parameters value: file %s on line %d\r\n", file, line) */
+void assert_failed(uint8_t *file, uint32_t line) {
+    /* USER CODE BEGIN 6 */
+  /* User can add his own implementation to report the file name and line
+ number,      ex: printf("Wrong parameters value: file %s on line %d\r\n", file,
+ line) */
   /* USER CODE END 6 */
 }
 #endif /* USE_FULL_ASSERT */
 
 void print_vpc3_registers(void) {
-    uint8_t status_lo = Vpc3Read(0x04);
-    uint8_t status_hi = Vpc3Read(0x05);
-    uint8_t mode_reg1 = Vpc3Read(0x07);
-    uint8_t control_reg = Vpc3Read(0x08);
-    uint8_t mode_reg2 = Vpc3Read(0x09);
-    uint8_t int_reg_l = Vpc3Read(0x0A);
-    uint8_t int_reg_h = Vpc3Read(0x0B);
-    uint8_t cfg_ptr = Vpc3Read(0x34);
+  uint8_t status_lo = Vpc3Read(bVpc3RoStatus_L);
+  uint8_t status_hi = Vpc3Read(bVpc3RoStatus_H);
+  uint8_t mode_reg1 = Vpc3Read(bVpc3RoModeReg1);
+  uint8_t control_reg = Vpc3Read(bVpc3WoControlCommandReg);
+  uint8_t mode_reg2 = Vpc3Read(bVpc3WoModeReg2);
+  uint8_t int_reg_l = Vpc3Read(bVpc3RoIntReg_L);
+  uint8_t int_reg_h = Vpc3Read(bVpc3RoIntReg_H);
+  uint8_t cfg_ptr = Vpc3Read(bVpc3RwReadCfgBufPtr);
 
-    printf("VPC3+S REGISTERS:\r\n");
-    printf("  STATUS_L   (0x04): 0x%02X\r\n", status_lo);
-    printf("  STATUS_H   (0x05): 0x%02X\r\n", status_hi);
-    printf("  MODE_REG_1 (0x07): 0x%02X\r\n", mode_reg1);
-    printf("  CONTROL_REG(0x08): 0x%02X\r\n", control_reg);
-    printf("  MODE_REG_2 (0x09): 0x%02X\r\n", mode_reg2);
-    printf("  INT_REG_L  (0x0A): 0x%02X\r\n", int_reg_l);
-    printf("  INT_REG_H  (0x0B): 0x%02X\r\n", int_reg_h);
-    printf("  CFG_PTR    (0x34): 0x%02X\r\n", cfg_ptr);
-    printf("\r\n");
+  printf("VPC3+S REGISTERS:\r\n");
+  printf("  STATUS_L   (0x%02X): 0x%02X\r\n",
+         (uint8_t)(bVpc3RoStatus_L - Vpc3AsicAddress), status_lo);
+  printf("  STATUS_H   (0x%02X): 0x%02X\r\n",
+         (uint8_t)(bVpc3RoStatus_H - Vpc3AsicAddress), status_hi);
+  printf("  MODE_REG_1 (0x%02X): 0x%02X\r\n",
+         (uint8_t)(bVpc3RoModeReg1 - Vpc3AsicAddress), mode_reg1);
+  printf("  CONTROL_REG(0x%02X): 0x%02X\r\n",
+         (uint8_t)(bVpc3WoControlCommandReg - Vpc3AsicAddress), control_reg);
+  printf("  MODE_REG_2 (0x%02X): 0x%02X\r\n",
+         (uint8_t)(bVpc3WoModeReg2 - Vpc3AsicAddress), mode_reg2);
+  printf("  INT_REG_L  (0x%02X): 0x%02X\r\n",
+         (uint8_t)(bVpc3RoIntReg_L - Vpc3AsicAddress), int_reg_l);
+  printf("  INT_REG_H  (0x%02X): 0x%02X\r\n",
+         (uint8_t)(bVpc3RoIntReg_H - Vpc3AsicAddress), int_reg_h);
+  printf("  CFG_PTR    (0x%02X): 0x%02X\r\n",
+         (uint8_t)(bVpc3RwReadCfgBufPtr - Vpc3AsicAddress), cfg_ptr);
+  printf("\r\n");
 }
 
 void print_vpc3_state(void) {
-    uint8_t status_l = Vpc3Read(0x04);
-    uint8_t dp_state = (status_l & MASK_DP_STATE) >> 5;
+  uint8_t status_l = Vpc3Read(0x04);
+  uint8_t dp_state = (status_l & MASK_DP_STATE) >> 5;
 
-    printf("PROFIBUS STATE: STATUS_L = 0x%02X -> ", status_l);
+  printf("PROFIBUS STATE: STATUS_L = 0x%02X -> ", status_l);
 
-    switch(dp_state) {
-        case WAIT_PRM:
-            printf("WAIT_PRM (Waiting for parameterization telegram)");
-            break;
-        case WAIT_CFG:
-            printf("WAIT_CFG (Waiting for configuration telegram)");
-            break;
-        case DATA_EX:
-            printf("DATA_EX (Data Exchange Active)");
-            break;
-        case DP_ERROR:
-             printf("DP_ERROR (PROFIBUS Error State)");
-             break;
-        default:
-            // Check other status flags if not in a standard DP state
-            if (!(status_l & 0x01)) { // Check if OFFLINE
-                 printf("OFFLINE");
-            } else if (status_l & 0x80) { // Check for PASSIVE_IDLE (older method)
-                 printf("PASSIVE_IDLE");
-            }
-            else {
-                 printf("UNKNOWN (DP_STATE: %d)", dp_state);
-            }
-            break;
+  switch (dp_state) {
+  case WAIT_PRM:
+    printf("WAIT_PRM (Waiting for parameterization telegram)");
+    break;
+  case WAIT_CFG:
+    printf("WAIT_CFG (Waiting for configuration telegram)");
+    break;
+  case DATA_EX:
+    printf("DATA_EX (Data Exchange Active)");
+    break;
+  case DP_ERROR:
+    printf("DP_ERROR (PROFIBUS Error State)");
+    break;
+  default:
+    // Check other status flags if not in a standard DP state
+    if (!(status_l & 0x01)) { // Check if OFFLINE
+      printf("OFFLINE");
+    } else if (status_l & 0x80) { // Check for PASSIVE_IDLE (older method)
+      printf("PASSIVE_IDLE");
+    } else {
+      printf("UNKNOWN (DP_STATE: %d)", dp_state);
     }
-    printf("\r\n");
+    break;
+  }
+  printf("\r\n");
 }
 
 /************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/Core/Src/vpc3_spi.c
+++ b/Core/Src/vpc3_spi.c
@@ -1,47 +1,51 @@
-#include "platform.h"
 #include "dp_inc.h"
 #include "main.h"
+#include "platform.h"
 
 // --- Declaraciones de funciones de logging ---
-static void VPC3_LogMemoryAccess(VPC3_ADR address, const char* operation, const char* function_name);
-static void VPC3_LogDiagnosticAccess(VPC3_ADR address, const char* operation);
-#include <string.h>
-#include <stdio.h>
+static void VPC3_LogMemoryAccess(VPC3_ADR address, const char *operation,
+                                 const char *function_name);
+static void VPC3_LogDiagnosticAccess(VPC3_ADR address, const char *operation);
 #include "stm32f4xx_hal.h"
+#include <stdio.h>
+#include <string.h>
 
 /* External SPI handle declaration */
 extern SPI_HandleTypeDef hspi1;
 
 /* VPC3+S SPI Instruction Set */
-#define OPC_WR_BYTE   0x12  // Write Byte
-#define OPC_RD_BYTE   0x13  // Read Byte
-#define OPC_WR_ARRAY  0x02  // Write Array
-#define OPC_RD_ARRAY  0x03  // Read Array
+#define OPC_WR_BYTE 0x12  // Write Byte
+#define OPC_RD_BYTE 0x13  // Read Byte
+#define OPC_WR_ARRAY 0x02 // Write Array
+#define OPC_RD_ARRAY 0x03 // Read Array
 
 /* Configuration */
-#define VPC3_TIMEOUT_MS     100    // 100ms timeout for SPI
-#define VPC3_MAX_ARRAY_LEN  256   // Maximum array transfer length
+#define VPC3_TIMEOUT_MS 100    // 100ms timeout for SPI
+#define VPC3_MAX_ARRAY_LEN 256 // Maximum array transfer length
 
 /* VPC3+S timing requirements (cycles @100MHz) */
-#define VPC3_CSS_CYCLES     200   // tCSS: CS setup (2μs) - increased for reliability
-#define VPC3_CSH_CYCLES     200   // tCSH: CS hold (2μs) - increased for reliability
+#define VPC3_CSS_CYCLES 200 // tCSS: CS setup (2μs) - increased for reliability
+#define VPC3_CSH_CYCLES 200 // tCSH: CS hold (2μs) - increased for reliability
 
 /* Status codes */
 typedef enum {
-    VPC3_OK = 0,
-    VPC3_ERROR_SPI_HDR,
-    VPC3_ERROR_SPI_DATA,
-    VPC3_ERROR_PARAM,
-    VPC3_ERROR_LENGTH
+  VPC3_OK = 0,
+  VPC3_ERROR_SPI_HDR,
+  VPC3_ERROR_SPI_DATA,
+  VPC3_ERROR_PARAM,
+  VPC3_ERROR_LENGTH
 } VPC3_Status;
 
 // Prototipos de las funciones de bajo nivel que necesita la librería
 void Vpc3Write(VPC3_ADR wAddress, uint8_t bData);
 uint8_t Vpc3Read(VPC3_ADR wAddress);
 void Vpc3MemSet(VPC3_ADR wAddress, uint8_t bValue, uint16_t wLength);
-uint8_t Vpc3MemCmp(VPC3_UNSIGNED8_PTR pToVpc3Memory1, VPC3_UNSIGNED8_PTR pToVpc3Memory2, uint16_t wLength);
-void CopyToVpc3(VPC3_UNSIGNED8_PTR pToVpc3Memory, MEM_UNSIGNED8_PTR pLocalMemory, uint16_t wLength);
-void CopyFromVpc3(MEM_UNSIGNED8_PTR pLocalMemory, VPC3_UNSIGNED8_PTR pToVpc3Memory, uint16_t wLength);
+uint8_t Vpc3MemCmp(VPC3_UNSIGNED8_PTR pToVpc3Memory1,
+                   VPC3_UNSIGNED8_PTR pToVpc3Memory2, uint16_t wLength);
+void CopyToVpc3(VPC3_UNSIGNED8_PTR pToVpc3Memory,
+                MEM_UNSIGNED8_PTR pLocalMemory, uint16_t wLength);
+void CopyFromVpc3(MEM_UNSIGNED8_PTR pLocalMemory,
+                  VPC3_UNSIGNED8_PTR pToVpc3Memory, uint16_t wLength);
 
 /* External Profibus interrupt control */
 extern void DpAppl_DisableInterruptVPC3Channel1(void);
@@ -51,7 +55,8 @@ extern void DpAppl_EnableInterruptVPC3Channel1(void);
  * @brief Delay for CS setup/hold timing
  *//*-------------------------------------------------------------------------*/
 static inline void vpc3_cs_delay(void) {
-    for (volatile int i = 0; i < VPC3_CSS_CYCLES; i++);
+  for (volatile int i = 0; i < VPC3_CSS_CYCLES; i++)
+    ;
 }
 
 /*-------------------------------------------------------------------------*//**
@@ -60,22 +65,22 @@ static inline void vpc3_cs_delay(void) {
  * @return Received byte
  *//*-------------------------------------------------------------------------*/
 static uint8_t vpc3_spi_transfer(uint8_t byte) {
-    uint8_t rx;
-    HAL_StatusTypeDef status;
-    
-    // Use HAL_SPI_TransmitReceive for better timing control
-    status = HAL_SPI_TransmitReceive(&hspi1, &byte, &rx, 1, VPC3_TIMEOUT_MS);
-    
-    if (status != HAL_OK) {
-        printf("ERROR: SPI transfer failed with status %d\r\n", status);
-        // Don't return 0xFF as it might be a valid data value
-        // Instead, try to recover the SPI bus
-        HAL_SPI_Abort(&hspi1);
-        HAL_Delay(1);
-        return 0x00; // Return 0x00 as a safer default
-    }
-    
-    return rx;
+  uint8_t rx;
+  HAL_StatusTypeDef status;
+
+  // Use HAL_SPI_TransmitReceive for better timing control
+  status = HAL_SPI_TransmitReceive(&hspi1, &byte, &rx, 1, VPC3_TIMEOUT_MS);
+
+  if (status != HAL_OK) {
+    printf("ERROR: SPI transfer failed with status %d\r\n", status);
+    // Don't return 0xFF as it might be a valid data value
+    // Instead, try to recover the SPI bus
+    HAL_SPI_Abort(&hspi1);
+    HAL_Delay(1);
+    return 0x00; // Return 0x00 as a safer default
+  }
+
+  return rx;
 }
 
 /**
@@ -85,194 +90,226 @@ static uint8_t vpc3_spi_transfer(uint8_t byte) {
  * @param maxRetries Maximum number of retry attempts
  * @return 0 on success, 1 on failure
  */
-static uint8_t vpc3_write_with_retry(VPC3_ADR wAddress, uint8_t bData, uint8_t maxRetries) {
-    uint8_t attempts = 0;
-    uint8_t verify_value;
-    
-    while (attempts < maxRetries) {
-        attempts++;
-        
-        // 1. Iniciar transacción - CS bajo
-        HAL_GPIO_WritePin(VPC3_CS_PORT, VPC3_CS_PIN, GPIO_PIN_RESET);
-        vpc3_cs_delay(); // Delay para tCSS
-        
-        DpAppl_DisableInterruptVPC3Channel1();
-        
-        // 2. Enviar byte de instrucción (0x12 para WRITE BYTE)
-        vpc3_spi_transfer(OPC_WR_BYTE);
-        
-        // 3. Enviar dirección de 16 bits (MSB primero)
-        vpc3_spi_transfer((uint8_t)(wAddress >> 8)); // Byte alto de la dirección
-        vpc3_spi_transfer((uint8_t)wAddress);        // Byte bajo de la dirección
-        
-        // 4. Enviar el byte de datos
-        vpc3_spi_transfer(bData);
-        
-        // 5. Finalizar transacción - CS alto
-        vpc3_cs_delay(); // Delay para tCSH
-        HAL_GPIO_WritePin(VPC3_CS_PORT, VPC3_CS_PIN, GPIO_PIN_SET);
-        
-        DpAppl_EnableInterruptVPC3Channel1();
-        
-        // 6. Verificación con delay
-        HAL_Delay(2); // Longer delay for stabilization
-        
-        // 7. Read back and verify
-        verify_value = Vpc3Read(wAddress);
-        if (verify_value == bData) {
-            return 0; // Success
-        }
-        
-        // If verification failed, try again
-        HAL_Delay(1);
-    }
-    
-    return 1; // Failure after all retries
-}
+static uint8_t vpc3_write_with_retry(VPC3_ADR wAddress, uint8_t bData,
+                                     uint8_t maxRetries) {
+  uint8_t attempts = 0;
+  uint8_t verify_value;
 
-/**
- * @brief Escribe un byte en el VPC3+ siguiendo el protocolo exacto del manual.
- * @note La firma (void, dos parámetros) coincide con la declaración 'extern' en dp_inc.h.
- */
-void Vpc3Write(VPC3_ADR wAddress, uint8_t bData) {
-    // DEBUG: Monitoreo de escrituras a registros críticos
-    if (wAddress == 0x0C) {  // MODE_REG_2 (bVpc3WoModeReg2)
-        printf("DEBUG: [Vpc3Write] ⚠️ ESCRITURA a MODE_REG_2 (0x0C): 0x%02X\r\n", bData);
-        if (bData != 0x05) {
-            printf("DEBUG: [Vpc3Write] ⚠️ ADVERTENCIA: MODE_REG_2 se está configurando a 0x%02X en lugar de 0x05\r\n", bData);
-            printf("DEBUG: [Vpc3Write] ⚠️ VALOR INCORRECTO DETECTADO - Esto causará LECTURAS ILEGALES\r\n");
-        }
-        
-        // Stack trace para identificar quién está escribiendo
-        printf("DEBUG: [Vpc3Write] 📍 Stack trace - Escritura a MODE_REG_2 desde:\r\n");
-        printf("DEBUG: [Vpc3Write] 📍 - Función llamadora: %s\r\n", __FUNCTION__);
-        printf("DEBUG: [Vpc3Write] 📍 - Línea: %d\r\n", __LINE__);
-        printf("DEBUG: [Vpc3Write] 📍 - Archivo: %s\r\n", __FILE__);
-        
-        // SPI Protocol Debug
-        printf("DEBUG: [Vpc3Write] 🔧 SPI Protocol Debug - MODE_REG_2 write:\r\n");
-        printf("DEBUG: [Vpc3Write] 🔧 - Instruction: 0x%02X (OPC_WR_BYTE)\r\n", OPC_WR_BYTE);
-        printf("DEBUG: [Vpc3Write] 🔧 - Address: 0x%04X (High: 0x%02X, Low: 0x%02X)\r\n", wAddress, (uint8_t)(wAddress >> 8), (uint8_t)wAddress);
-        printf("DEBUG: [Vpc3Write] 🔧 - Data: 0x%02X\r\n", bData);
-    }
-    
-    if (wAddress == 0x09) {  // MODE_REG_1_R (bVpc3WoModeReg1_R)
-        printf("DEBUG: [Vpc3Write] ESCRITURA a MODE_REG_1_R (0x09): 0x%02X\r\n", bData);
-    }
-    
-    if (wAddress == 0x07 || wAddress == 0x08) {  // MODE_REG_0_H, MODE_REG_0_L
-        printf("DEBUG: [Vpc3Write] ESCRITURA a MODE_REG_0_%c (0x%02X): 0x%02X\r\n", 
-               (wAddress == 0x07) ? 'H' : 'L', wAddress, bData);
-    }
-    
-    if (wAddress == 0x0B) {  // MODE_REG_3
-        printf("DEBUG: [Vpc3Write] ESCRITURA a MODE_REG_3 (0x0B): 0x%02X\r\n", bData);
-    }
-
-    // Use retry mechanism for critical registers
-    uint8_t maxRetries = (wAddress == 0x0C) ? 5 : 1; // More retries for MODE_REG_2
-    uint8_t result = vpc3_write_with_retry(wAddress, bData, maxRetries);
-    
-    if (result != 0 && wAddress == 0x0C) {
-        printf("DEBUG: [Vpc3Write] ❌ ERROR: MODE_REG_2 write failed after %d retries!\r\n", maxRetries);
-    }
-}
-
-/**
- * @brief Lee un byte del VPC3+.
- * @note La firma (retorna uint8_t, un parámetro) coincide con la declaración 'extern' en dp_inc.h.
- */
-uint8_t Vpc3Read(VPC3_ADR wAddress) {
-    // --- Logging detallado de acceso a memoria ---
-    VPC3_LogMemoryAccess(wAddress, "READ", "Vpc3Read");
-    VPC3_LogDiagnosticAccess(wAddress, "READ");
-    
-    // --- Programación Defensiva: Verificación de Límites Adaptativa ---
-    if (!VPC3_IsAddressValid(wAddress)) {
-        printf("\r\n--- LECTURA ILEGAL DETECTADA EN Vpc3Read ---\r\n");
-        printf("ERROR: Intento de leer un byte desde una dirección (0x%04X) que está fuera de los límites de la RAM.\r\n",
-               (unsigned int)wAddress);
-        printf("Esta es una condición FATAL. Se retornará 0x00 para indicar el error.\r\n");
-        printf("--- FIN LECTURA ILEGAL ---\r\n");
-        return 0x00; // Retornar un valor de error claro
-    }
-    // --- Fin de la Verificación ---
+  while (attempts < maxRetries) {
+    attempts++;
 
     // 1. Iniciar transacción - CS bajo
     HAL_GPIO_WritePin(VPC3_CS_PORT, VPC3_CS_PIN, GPIO_PIN_RESET);
     vpc3_cs_delay(); // Delay para tCSS
-    
+
     DpAppl_DisableInterruptVPC3Channel1();
-    
-    // 2. Enviar byte de instrucción (0x13 para READ BYTE)
-    vpc3_spi_transfer(OPC_RD_BYTE);
-    
+
+    // 2. Enviar byte de instrucción (0x12 para WRITE BYTE)
+    vpc3_spi_transfer(OPC_WR_BYTE);
+
     // 3. Enviar dirección de 16 bits (MSB primero)
     vpc3_spi_transfer((uint8_t)(wAddress >> 8)); // Byte alto de la dirección
     vpc3_spi_transfer((uint8_t)wAddress);        // Byte bajo de la dirección
-    
-    // 4. Continuar generando 8 pulsos de reloj para leer el byte de datos
-    uint8_t bData = vpc3_spi_transfer(0x00); // Enviar dummy byte, recibir datos
-    
+
+    // 4. Enviar el byte de datos
+    vpc3_spi_transfer(bData);
+
     // 5. Finalizar transacción - CS alto
     vpc3_cs_delay(); // Delay para tCSH
     HAL_GPIO_WritePin(VPC3_CS_PORT, VPC3_CS_PIN, GPIO_PIN_SET);
-    
+
     DpAppl_EnableInterruptVPC3Channel1();
-    
-    return bData;
+
+    // 6. Verificación con delay
+    HAL_Delay(2); // Longer delay for stabilization
+
+    // 7. Read back and verify
+    verify_value = Vpc3Read(wAddress);
+    if (verify_value == bData) {
+      return 0; // Success
+    }
+
+    // If verification failed, try again
+    HAL_Delay(1);
+  }
+
+  return 1; // Failure after all retries
 }
 
 /**
- * @brief Detects the actual memory mode from MODE_REG_2 and adjusts calculations accordingly
+ * @brief Escribe un byte en el VPC3+ siguiendo el protocolo exacto del manual.
+ * @note La firma (void, dos parámetros) coincide con la declaración 'extern' en
+ * dp_inc.h.
+ */
+void Vpc3Write(VPC3_ADR wAddress, uint8_t bData) {
+  // DEBUG: Monitoreo de escrituras a registros críticos
+  if (wAddress == bVpc3WoModeReg2) { // MODE_REG_2
+    printf("DEBUG: [Vpc3Write] ⚠️ ESCRITURA a MODE_REG_2 (0x%02X): 0x%02X\r\n",
+           (uint8_t)(bVpc3WoModeReg2 - Vpc3AsicAddress), bData);
+    if (bData != 0x05) {
+      printf("DEBUG: [Vpc3Write] ⚠️ ADVERTENCIA: MODE_REG_2 se está "
+             "configurando a 0x%02X en lugar de 0x05\r\n",
+             bData);
+      printf("DEBUG: [Vpc3Write] ⚠️ VALOR INCORRECTO DETECTADO - Esto causará "
+             "LECTURAS ILEGALES\r\n");
+    }
+
+    // Stack trace para identificar quién está escribiendo
+    printf("DEBUG: [Vpc3Write] 📍 Stack trace - Escritura a MODE_REG_2 "
+           "desde:\r\n");
+    printf("DEBUG: [Vpc3Write] 📍 - Función llamadora: %s\r\n", __FUNCTION__);
+    printf("DEBUG: [Vpc3Write] 📍 - Línea: %d\r\n", __LINE__);
+    printf("DEBUG: [Vpc3Write] 📍 - Archivo: %s\r\n", __FILE__);
+
+    // SPI Protocol Debug
+    printf("DEBUG: [Vpc3Write] 🔧 SPI Protocol Debug - MODE_REG_2 write:\r\n");
+    printf("DEBUG: [Vpc3Write] 🔧 - Instruction: 0x%02X (OPC_WR_BYTE)\r\n",
+           OPC_WR_BYTE);
+    printf("DEBUG: [Vpc3Write] 🔧 - Address: 0x%04X (High: 0x%02X, Low: "
+           "0x%02X)\r\n",
+           wAddress, (uint8_t)(wAddress >> 8), (uint8_t)wAddress);
+    printf("DEBUG: [Vpc3Write] 🔧 - Data: 0x%02X\r\n", bData);
+  }
+
+  if (wAddress == bVpc3WoModeReg1_R) { // MODE_REG_1_R
+    printf("DEBUG: [Vpc3Write] ESCRITURA a MODE_REG_1_R (0x%02X): 0x%02X\r\n",
+           (uint8_t)(bVpc3WoModeReg1_R - Vpc3AsicAddress), bData);
+  }
+
+  if (wAddress == bVpc3RwModeReg0_H ||
+      wAddress == bVpc3RwModeReg0_L) { // MODE_REG_0_H, MODE_REG_0_L
+    printf("DEBUG: [Vpc3Write] ESCRITURA a MODE_REG_0_%c (0x%02X): 0x%02X\r\n",
+           (wAddress == bVpc3RwModeReg0_H) ? 'H' : 'L',
+           (uint8_t)(wAddress - Vpc3AsicAddress), bData);
+  }
+
+  if (wAddress == bVpc3WoModeReg3) { // MODE_REG_3
+    printf("DEBUG: [Vpc3Write] ESCRITURA a MODE_REG_3 (0x%02X): 0x%02X\r\n",
+           (uint8_t)(bVpc3WoModeReg3 - Vpc3AsicAddress), bData);
+  }
+
+  if (wAddress == bVpc3WoMinTsdrVal) { // MinTsdrVal
+    printf("DEBUG: [Vpc3Write] ESCRITURA a MinTsdrVal (0x%02X): 0x%02X\r\n",
+           (uint8_t)(bVpc3WoMinTsdrVal - Vpc3AsicAddress), bData);
+  }
+
+  // Use retry mechanism for critical registers
+  uint8_t maxRetries =
+      (wAddress == bVpc3WoModeReg2) ? 5 : 1; // More retries for MODE_REG_2
+  uint8_t result = vpc3_write_with_retry(wAddress, bData, maxRetries);
+
+  if (result != 0 && wAddress == bVpc3WoModeReg2) {
+    printf("DEBUG: [Vpc3Write] ❌ ERROR: MODE_REG_2 write failed after %d "
+           "retries!\r\n",
+           maxRetries);
+  }
+}
+
+/**
+ * @brief Lee un byte del VPC3+.
+ * @note La firma (retorna uint8_t, un parámetro) coincide con la declaración
+ * 'extern' en dp_inc.h.
+ */
+uint8_t Vpc3Read(VPC3_ADR wAddress) {
+  // --- Logging detallado de acceso a memoria ---
+  VPC3_LogMemoryAccess(wAddress, "READ", "Vpc3Read");
+  VPC3_LogDiagnosticAccess(wAddress, "READ");
+
+  // --- Programación Defensiva: Verificación de Límites Adaptativa ---
+  if (!VPC3_IsAddressValid(wAddress)) {
+    printf("\r\n--- LECTURA ILEGAL DETECTADA EN Vpc3Read ---\r\n");
+    printf("ERROR: Intento de leer un byte desde una dirección (0x%04X) que "
+           "está fuera de los límites de la RAM.\r\n",
+           (unsigned int)wAddress);
+    printf("Esta es una condición FATAL. Se retornará 0x00 para indicar el "
+           "error.\r\n");
+    printf("--- FIN LECTURA ILEGAL ---\r\n");
+    return 0x00; // Retornar un valor de error claro
+  }
+  // --- Fin de la Verificación ---
+
+  // 1. Iniciar transacción - CS bajo
+  HAL_GPIO_WritePin(VPC3_CS_PORT, VPC3_CS_PIN, GPIO_PIN_RESET);
+  vpc3_cs_delay(); // Delay para tCSS
+
+  DpAppl_DisableInterruptVPC3Channel1();
+
+  // 2. Enviar byte de instrucción (0x13 para READ BYTE)
+  vpc3_spi_transfer(OPC_RD_BYTE);
+
+  // 3. Enviar dirección de 16 bits (MSB primero)
+  vpc3_spi_transfer((uint8_t)(wAddress >> 8)); // Byte alto de la dirección
+  vpc3_spi_transfer((uint8_t)wAddress);        // Byte bajo de la dirección
+
+  // 4. Continuar generando 8 pulsos de reloj para leer el byte de datos
+  uint8_t bData = vpc3_spi_transfer(0x00); // Enviar dummy byte, recibir datos
+
+  // 5. Finalizar transacción - CS alto
+  vpc3_cs_delay(); // Delay para tCSH
+  HAL_GPIO_WritePin(VPC3_CS_PORT, VPC3_CS_PIN, GPIO_PIN_SET);
+
+  DpAppl_EnableInterruptVPC3Channel1();
+
+  return bData;
+}
+
+/**
+ * @brief Detects the actual memory mode from MODE_REG_2 and adjusts
+ * calculations accordingly
  * @return 0 for 2KB mode, 1 for 4KB mode, 2 for unknown/corrupted mode
  */
 uint8_t VPC3_DetectActualMemoryMode(void) {
-    // Add timeout protection to prevent hanging
-    uint32_t start_time = HAL_GetTick();
-    uint8_t mode_reg_2;
-    uint8_t attempts = 0;
-    const uint8_t max_attempts = 3;
-    
-    while (attempts < max_attempts) {
-        attempts++;
-        
-        // Check for timeout (100ms max)
-        if (HAL_GetTick() - start_time > 100) {
-            printf("DEBUG: [VPC3_DetectActualMemoryMode] ⚠️ Timeout reading MODE_REG_2\r\n");
-            return 2; // Unknown/corrupted mode
-        }
-        
-        mode_reg_2 = Vpc3Read(bVpc3WoModeReg2);
-        
-        // Check if we got a valid response (not 0xFF which indicates no response)
-        if (mode_reg_2 != 0xFF) {
-            break;
-        }
-        
-        // Small delay before retry
-        HAL_Delay(1);
+  // Add timeout protection to prevent hanging
+  uint32_t start_time = HAL_GetTick();
+  uint8_t mode_reg_2;
+  uint8_t attempts = 0;
+  const uint8_t max_attempts = 3;
+
+  while (attempts < max_attempts) {
+    attempts++;
+
+    // Check for timeout (100ms max)
+    if (HAL_GetTick() - start_time > 100) {
+      printf("DEBUG: [VPC3_DetectActualMemoryMode] ⚠️ Timeout reading "
+             "MODE_REG_2\r\n");
+      return 2; // Unknown/corrupted mode
     }
-    
-    if (attempts >= max_attempts) {
-        printf("DEBUG: [VPC3_DetectActualMemoryMode] ❌ Failed to read MODE_REG_2 after %d attempts\r\n", max_attempts);
-        return 2; // Unknown/corrupted mode
+
+    mode_reg_2 = Vpc3Read(bVpc3WoModeReg2);
+
+    // Check if we got a valid response (not 0xFF which indicates no response)
+    if (mode_reg_2 != 0xFF) {
+      break;
     }
-    
-    uint8_t bit_7 = (mode_reg_2 >> 7) & 0x01;
-    
-    printf("DEBUG: [VPC3_DetectActualMemoryMode] MODE_REG_2=0x%02X, bit7=%d\r\n", mode_reg_2, bit_7);
-    
-    if (bit_7 == 0) {
-        printf("DEBUG: [VPC3_DetectActualMemoryMode] ✅ Detected 2KB mode\r\n");
-        return 0; // 2KB mode
-    } else if (bit_7 == 1) {
-        printf("DEBUG: [VPC3_DetectActualMemoryMode] ⚠️ Detected 4KB mode (unexpected)\r\n");
-        return 1; // 4KB mode
-    } else {
-        printf("DEBUG: [VPC3_DetectActualMemoryMode] ❌ Unknown/corrupted mode\r\n");
-        return 2; // Unknown
-    }
+
+    // Small delay before retry
+    HAL_Delay(1);
+  }
+
+  if (attempts >= max_attempts) {
+    printf("DEBUG: [VPC3_DetectActualMemoryMode] ❌ Failed to read MODE_REG_2 "
+           "after %d attempts\r\n",
+           max_attempts);
+    return 2; // Unknown/corrupted mode
+  }
+
+  uint8_t bit_7 = (mode_reg_2 >> 7) & 0x01;
+
+  printf("DEBUG: [VPC3_DetectActualMemoryMode] MODE_REG_2=0x%02X, bit7=%d\r\n",
+         mode_reg_2, bit_7);
+
+  if (bit_7 == 0) {
+    printf("DEBUG: [VPC3_DetectActualMemoryMode] ✅ Detected 2KB mode\r\n");
+    return 0; // 2KB mode
+  } else if (bit_7 == 1) {
+    printf("DEBUG: [VPC3_DetectActualMemoryMode] ⚠️ Detected 4KB mode "
+           "(unexpected)\r\n");
+    return 1; // 4KB mode
+  } else {
+    printf(
+        "DEBUG: [VPC3_DetectActualMemoryMode] ❌ Unknown/corrupted mode\r\n");
+    return 2; // Unknown
+  }
 }
 
 /**
@@ -280,17 +317,18 @@ uint8_t VPC3_DetectActualMemoryMode(void) {
  * @return Actual RAM length in bytes
  */
 uint16_t VPC3_GetActualRamLength(void) {
-    uint8_t actual_mode = VPC3_DetectActualMemoryMode();
-    
-    switch (actual_mode) {
-        case 0: // 2KB mode
-            return 0x0800; // 2KB
-        case 1: // 4KB mode
-            return 0x1000; // 4KB
-        default: // Unknown/corrupted
-            printf("DEBUG: [VPC3_GetActualRamLength] ⚠️ Using conservative 2KB limit\r\n");
-            return 0x0800; // Conservative fallback
-    }
+  uint8_t actual_mode = VPC3_DetectActualMemoryMode();
+
+  switch (actual_mode) {
+  case 0:          // 2KB mode
+    return 0x0800; // 2KB
+  case 1:          // 4KB mode
+    return 0x1000; // 4KB
+  default:         // Unknown/corrupted
+    printf(
+        "DEBUG: [VPC3_GetActualRamLength] ⚠️ Using conservative 2KB limit\r\n");
+    return 0x0800; // Conservative fallback
+  }
 }
 
 /**
@@ -299,17 +337,18 @@ uint16_t VPC3_GetActualRamLength(void) {
  * @return 1 if address is valid, 0 if invalid
  */
 uint8_t VPC3_IsAddressValid(VPC3_ADR address) {
-    // Use a conservative approach during initialization to prevent hangs
-    // For now, use the configured ASIC_RAM_LENGTH instead of trying to detect it
-    uint16_t ram_limit = ASIC_RAM_LENGTH;
-    
-    if (address >= ram_limit) {
-        printf("DEBUG: [VPC3_IsAddressValid] ❌ Address 0x%04X exceeds RAM limit 0x%04X\r\n", 
-               address, ram_limit);
-        return 0;
-    }
-    
-    return 1;
+  // Use a conservative approach during initialization to prevent hangs
+  // For now, use the configured ASIC_RAM_LENGTH instead of trying to detect it
+  uint16_t ram_limit = ASIC_RAM_LENGTH;
+
+  if (address >= ram_limit) {
+    printf("DEBUG: [VPC3_IsAddressValid] ❌ Address 0x%04X exceeds RAM limit "
+           "0x%04X\r\n",
+           address, ram_limit);
+    return 0;
+  }
+
+  return 1;
 }
 
 /**
@@ -318,48 +357,64 @@ uint8_t VPC3_IsAddressValid(VPC3_ADR address) {
  * @param operation "READ" or "WRITE"
  * @param function_name The calling function name
  */
-static void VPC3_LogMemoryAccess(VPC3_ADR address, const char* operation, const char* function_name) {
-    // Solo mostrar logs para direcciones fuera de rango o críticas
-    if (address >= ASIC_RAM_LENGTH || address == 2046) {
-        printf("🔍 [VPC3_LogMemoryAccess] === ANÁLISIS DE DIRECCIÓN DE MEMORIA ===\r\n");
-        printf("🔍 [VPC3_LogMemoryAccess] Operación: %s\r\n", operation);
-        printf("🔍 [VPC3_LogMemoryAccess] Función llamadora: %s\r\n", function_name);
-        printf("🔍 [VPC3_LogMemoryAccess] Dirección: 0x%04X (%u decimal)\r\n", address, address);
-        
-        // Análisis de rangos de memoria
-        printf("🔍 [VPC3_LogMemoryAccess] Rangos de memoria:\r\n");
-        printf("🔍 [VPC3_LogMemoryAccess] - 2KB: 0x0000-0x07FF (0-2047)\r\n");
-        printf("🔍 [VPC3_LogMemoryAccess] - 4KB: 0x0000-0x0FFF (0-4095)\r\n");
-        printf("🔍 [VPC3_LogMemoryAccess] - ASIC_RAM_LENGTH: 0x%04X (%u)\r\n", ASIC_RAM_LENGTH, ASIC_RAM_LENGTH);
-        
-        // Verificar si la dirección está en rango
-        if (address < ASIC_RAM_LENGTH) {
-            printf("🔍 [VPC3_LogMemoryAccess] ✅ Dirección VÁLIDA dentro del rango\r\n");
-        } else {
-            printf("🔍 [VPC3_LogMemoryAccess] ❌ Dirección FUERA DE RANGO!\r\n");
-            printf("🔍 [VPC3_LogMemoryAccess] ❌ Excede ASIC_RAM_LENGTH en %u bytes\r\n", address - ASIC_RAM_LENGTH);
-        }
-        
-        // Análisis especial para dirección 2046
-        if (address == 2046) {
-            printf("🔍 [VPC3_LogMemoryAccess] 🚨 DIRECCIÓN CRÍTICA 2046 DETECTADA!\r\n");
-            printf("🔍 [VPC3_LogMemoryAccess] 🚨 Esta es la dirección del registro de diagnóstico\r\n");
-            printf("🔍 [VPC3_LogMemoryAccess] 🚨 En modo 2KB: 2046 está en el ÚLTIMO byte (0x7FE)\r\n");
-            printf("🔍 [VPC3_LogMemoryAccess] 🚨 En modo 4KB: 2046 está en el rango medio (0x7FE)\r\n");
-            
-            // Verificar MODE_REG_2 para determinar el modo actual
-            uint8_t mode_reg_2 = Vpc3Read(bVpc3WoModeReg2);
-            uint8_t bit_7 = (mode_reg_2 >> 7) & 0x01;
-            printf("🔍 [VPC3_LogMemoryAccess] 🚨 MODE_REG_2 actual: 0x%02X, bit7=%d\r\n", mode_reg_2, bit_7);
-            printf("🔍 [VPC3_LogMemoryAccess] 🚨 Modo detectado: %s\r\n", bit_7 ? "4KB" : "2KB");
-            
-            if (bit_7 == 0 && address >= 2048) {
-                printf("🔍 [VPC3_LogMemoryAccess] 🚨 CONFLICTO: Modo 2KB pero dirección >= 2048\r\n");
-            }
-        }
-        
-        printf("🔍 [VPC3_LogMemoryAccess] === FIN ANÁLISIS ===\r\n");
+static void VPC3_LogMemoryAccess(VPC3_ADR address, const char *operation,
+                                 const char *function_name) {
+  // Solo mostrar logs para direcciones fuera de rango o críticas
+  if (address >= ASIC_RAM_LENGTH || address == 2046) {
+    printf("🔍 [VPC3_LogMemoryAccess] === ANÁLISIS DE DIRECCIÓN DE MEMORIA "
+           "===\r\n");
+    printf("🔍 [VPC3_LogMemoryAccess] Operación: %s\r\n", operation);
+    printf("🔍 [VPC3_LogMemoryAccess] Función llamadora: %s\r\n",
+           function_name);
+    printf("🔍 [VPC3_LogMemoryAccess] Dirección: 0x%04X (%u decimal)\r\n",
+           address, address);
+
+    // Análisis de rangos de memoria
+    printf("🔍 [VPC3_LogMemoryAccess] Rangos de memoria:\r\n");
+    printf("🔍 [VPC3_LogMemoryAccess] - 2KB: 0x0000-0x07FF (0-2047)\r\n");
+    printf("🔍 [VPC3_LogMemoryAccess] - 4KB: 0x0000-0x0FFF (0-4095)\r\n");
+    printf("🔍 [VPC3_LogMemoryAccess] - ASIC_RAM_LENGTH: 0x%04X (%u)\r\n",
+           ASIC_RAM_LENGTH, ASIC_RAM_LENGTH);
+
+    // Verificar si la dirección está en rango
+    if (address < ASIC_RAM_LENGTH) {
+      printf(
+          "🔍 [VPC3_LogMemoryAccess] ✅ Dirección VÁLIDA dentro del rango\r\n");
+    } else {
+      printf("🔍 [VPC3_LogMemoryAccess] ❌ Dirección FUERA DE RANGO!\r\n");
+      printf(
+          "🔍 [VPC3_LogMemoryAccess] ❌ Excede ASIC_RAM_LENGTH en %u bytes\r\n",
+          address - ASIC_RAM_LENGTH);
     }
+
+    // Análisis especial para dirección 2046
+    if (address == 2046) {
+      printf(
+          "🔍 [VPC3_LogMemoryAccess] 🚨 DIRECCIÓN CRÍTICA 2046 DETECTADA!\r\n");
+      printf("🔍 [VPC3_LogMemoryAccess] 🚨 Esta es la dirección del registro "
+             "de diagnóstico\r\n");
+      printf("🔍 [VPC3_LogMemoryAccess] 🚨 En modo 2KB: 2046 está en el ÚLTIMO "
+             "byte (0x7FE)\r\n");
+      printf("🔍 [VPC3_LogMemoryAccess] 🚨 En modo 4KB: 2046 está en el rango "
+             "medio (0x7FE)\r\n");
+
+      // Verificar MODE_REG_2 para determinar el modo actual
+      uint8_t mode_reg_2 = Vpc3Read(bVpc3WoModeReg2);
+      uint8_t bit_7 = (mode_reg_2 >> 7) & 0x01;
+      printf(
+          "🔍 [VPC3_LogMemoryAccess] 🚨 MODE_REG_2 actual: 0x%02X, bit7=%d\r\n",
+          mode_reg_2, bit_7);
+      printf("🔍 [VPC3_LogMemoryAccess] 🚨 Modo detectado: %s\r\n",
+             bit_7 ? "4KB" : "2KB");
+
+      if (bit_7 == 0 && address >= 2048) {
+        printf("🔍 [VPC3_LogMemoryAccess] 🚨 CONFLICTO: Modo 2KB pero "
+               "dirección >= 2048\r\n");
+      }
+    }
+
+    printf("🔍 [VPC3_LogMemoryAccess] === FIN ANÁLISIS ===\r\n");
+  }
 }
 
 /**
@@ -367,179 +422,210 @@ static void VPC3_LogMemoryAccess(VPC3_ADR address, const char* operation, const 
  * @param address The diagnostic register address
  * @param operation "READ" or "WRITE"
  */
-static void VPC3_LogDiagnosticAccess(VPC3_ADR address, const char* operation) {
-    if (address == 2046 || address == 0x7FE) {
-        printf("🚨 [VPC3_LogDiagnosticAccess] === ACCESO AL REGISTRO DE DIAGNÓSTICO ===\r\n");
-        printf("🚨 [VPC3_LogDiagnosticAccess] Operación: %s\r\n", operation);
-        printf("🚨 [VPC3_LogDiagnosticAccess] Dirección: 0x%04X (%u decimal)\r\n", address, address);
-        
-        // Análisis del modo de memoria actual
-        uint8_t mode_reg_2 = Vpc3Read(bVpc3WoModeReg2);
-        uint8_t bit_7 = (mode_reg_2 >> 7) & 0x01;
-        
-        printf("🚨 [VPC3_LogDiagnosticAccess] MODE_REG_2: 0x%02X (bit7=%d)\r\n", mode_reg_2, bit_7);
-        printf("🚨 [VPC3_LogDiagnosticAccess] Modo actual: %s\r\n", bit_7 ? "4KB" : "2KB");
-        printf("🚨 [VPC3_LogDiagnosticAccess] ASIC_RAM_LENGTH: 0x%04X (%u)\r\n", ASIC_RAM_LENGTH, ASIC_RAM_LENGTH);
-        
-        // Verificar si hay conflicto
-        if (bit_7 == 0 && address >= 2048) {
-            printf("🚨 [VPC3_LogDiagnosticAccess] ❌ CONFLICTO DETECTADO!\r\n");
-            printf("🚨 [VPC3_LogDiagnosticAccess] ❌ Modo 2KB pero dirección >= 2048\r\n");
-            printf("🚨 [VPC3_LogDiagnosticAccess] ❌ Esto puede causar desbordamiento de memoria\r\n");
-        } else if (bit_7 == 1 && address < 2048) {
-            printf("🚨 [VPC3_LogDiagnosticAccess] ⚠️ Posible subutilización de memoria 4KB\r\n");
-        } else {
-            printf("🚨 [VPC3_LogDiagnosticAccess] ✅ Configuración coherente\r\n");
-        }
-        
-        printf("🚨 [VPC3_LogDiagnosticAccess] === FIN ANÁLISIS DIAGNÓSTICO ===\r\n");
+static void VPC3_LogDiagnosticAccess(VPC3_ADR address, const char *operation) {
+  if (address == 2046 || address == 0x7FE) {
+    printf("🚨 [VPC3_LogDiagnosticAccess] === ACCESO AL REGISTRO DE "
+           "DIAGNÓSTICO ===\r\n");
+    printf("🚨 [VPC3_LogDiagnosticAccess] Operación: %s\r\n", operation);
+    printf("🚨 [VPC3_LogDiagnosticAccess] Dirección: 0x%04X (%u decimal)\r\n",
+           address, address);
+
+    // Análisis del modo de memoria actual
+    uint8_t mode_reg_2 = Vpc3Read(bVpc3WoModeReg2);
+    uint8_t bit_7 = (mode_reg_2 >> 7) & 0x01;
+
+    printf("🚨 [VPC3_LogDiagnosticAccess] MODE_REG_2: 0x%02X (bit7=%d)\r\n",
+           mode_reg_2, bit_7);
+    printf("🚨 [VPC3_LogDiagnosticAccess] Modo actual: %s\r\n",
+           bit_7 ? "4KB" : "2KB");
+    printf("🚨 [VPC3_LogDiagnosticAccess] ASIC_RAM_LENGTH: 0x%04X (%u)\r\n",
+           ASIC_RAM_LENGTH, ASIC_RAM_LENGTH);
+
+    // Verificar si hay conflicto
+    if (bit_7 == 0 && address >= 2048) {
+      printf("🚨 [VPC3_LogDiagnosticAccess] ❌ CONFLICTO DETECTADO!\r\n");
+      printf("🚨 [VPC3_LogDiagnosticAccess] ❌ Modo 2KB pero dirección >= "
+             "2048\r\n");
+      printf("🚨 [VPC3_LogDiagnosticAccess] ❌ Esto puede causar "
+             "desbordamiento de memoria\r\n");
+    } else if (bit_7 == 1 && address < 2048) {
+      printf("🚨 [VPC3_LogDiagnosticAccess] ⚠️ Posible subutilización de "
+             "memoria 4KB\r\n");
+    } else {
+      printf("🚨 [VPC3_LogDiagnosticAccess] ✅ Configuración coherente\r\n");
     }
+
+    printf(
+        "🚨 [VPC3_LogDiagnosticAccess] === FIN ANÁLISIS DIAGNÓSTICO ===\r\n");
+  }
 }
 
 // Tus funciones de array ya son eficientes, las mantenemos.
-VPC3_Status Vpc3WriteArray(VPC3_UNSIGNED8_PTR dst_vpc, const uint8_t *src_local, uint16_t len) {
-    VPC3_ADR addr = (VPC3_ADR)(uintptr_t)dst_vpc;
-    uint8_t cmd[3] = {OPC_WR_ARRAY, (uint8_t)(addr >> 8), (uint8_t)addr};
+VPC3_Status Vpc3WriteArray(VPC3_UNSIGNED8_PTR dst_vpc, const uint8_t *src_local,
+                           uint16_t len) {
+  VPC3_ADR addr = (VPC3_ADR)(uintptr_t)dst_vpc;
+  uint8_t cmd[3] = {OPC_WR_ARRAY, (uint8_t)(addr >> 8), (uint8_t)addr};
+
+  DpAppl_DisableInterruptVPC3Channel1();
+  VPC3_CS_LOW();
+  HAL_SPI_Transmit(&hspi1, cmd, 3, VPC3_TIMEOUT_MS);
+  HAL_StatusTypeDef status =
+      HAL_SPI_Transmit(&hspi1, (uint8_t *)src_local, len, VPC3_TIMEOUT_MS);
+  VPC3_CS_HIGH();
+  DpAppl_EnableInterruptVPC3Channel1();
+
+  return (status == HAL_OK) ? VPC3_OK : VPC3_ERROR_SPI_DATA;
+}
+
+VPC3_Status Vpc3ReadArray(uint8_t *dst_local, VPC3_UNSIGNED8_PTR src_vpc,
+                          uint16_t len) {
+  VPC3_ADR addr = (VPC3_ADR)(uintptr_t)src_vpc;
+  uint8_t cmd[3] = {OPC_RD_ARRAY, (uint8_t)(addr >> 8), (uint8_t)addr};
+
+  DpAppl_DisableInterruptVPC3Channel1();
+  VPC3_CS_LOW();
+  HAL_SPI_Transmit(&hspi1, cmd, 3, VPC3_TIMEOUT_MS);
+  HAL_StatusTypeDef status =
+      HAL_SPI_Receive(&hspi1, dst_local, len, VPC3_TIMEOUT_MS);
+  VPC3_CS_HIGH();
+  DpAppl_EnableInterruptVPC3Channel1();
+
+  return (status == HAL_OK) ? VPC3_OK : VPC3_ERROR_SPI_DATA;
+}
+
+/**
+ * @brief Escribe un array de bytes en el VPC3+. Esta función es llamada por el
+ * macro CopyToVpc3.
+ */
+void CopyToVpc3(VPC3_UNSIGNED8_PTR pToVpc3Memory,
+                MEM_UNSIGNED8_PTR pLocalMemory, uint16_t wLength) {
+  const uint16_t MAX_TRANSFER_SIZE =
+      240; // Tamaño máximo seguro para transferencias SPI
+  VPC3_ADR addr = (VPC3_ADR)(uintptr_t)pToVpc3Memory;
+
+  uint16_t remaining = wLength;
+  uint16_t offset = 0;
+
+  while (remaining > 0) {
+    uint16_t transferSize =
+        (remaining > MAX_TRANSFER_SIZE) ? MAX_TRANSFER_SIZE : remaining;
+    uint8_t cmd[3] = {OPC_WR_ARRAY, (uint8_t)((addr + offset) >> 8),
+                      (uint8_t)(addr + offset)};
 
     DpAppl_DisableInterruptVPC3Channel1();
     VPC3_CS_LOW();
     HAL_SPI_Transmit(&hspi1, cmd, 3, VPC3_TIMEOUT_MS);
-    HAL_StatusTypeDef status = HAL_SPI_Transmit(&hspi1, (uint8_t*)src_local, len, VPC3_TIMEOUT_MS);
+    HAL_SPI_Transmit(&hspi1, (uint8_t *)pLocalMemory + offset, transferSize,
+                     VPC3_TIMEOUT_MS);
     VPC3_CS_HIGH();
     DpAppl_EnableInterruptVPC3Channel1();
 
-    return (status == HAL_OK) ? VPC3_OK : VPC3_ERROR_SPI_DATA;
+    offset += transferSize;
+    remaining -= transferSize;
+  }
 }
 
-VPC3_Status Vpc3ReadArray(uint8_t *dst_local, VPC3_UNSIGNED8_PTR src_vpc, uint16_t len) {
-    VPC3_ADR addr = (VPC3_ADR)(uintptr_t)src_vpc;
-    uint8_t cmd[3] = {OPC_RD_ARRAY, (uint8_t)(addr >> 8), (uint8_t)addr};
+/**
+ * @brief Lee un array de bytes del VPC3+. Esta es llamada por el macro
+ * CopyFromVpc3.
+ */
+void CopyFromVpc3(MEM_UNSIGNED8_PTR pLocalMemory,
+                  VPC3_UNSIGNED8_PTR pToVpc3Memory, uint16_t wLength) {
+  VPC3_ADR addr = (VPC3_ADR)(uintptr_t)pToVpc3Memory;
+
+  // --- Programación Defensiva: Verificación de Límites Conservativa ---
+  uint16_t ram_limit = ASIC_RAM_LENGTH;
+  if ((addr + wLength) > ram_limit) {
+    printf("\r\n--- LECTURA ILEGAL DETECTADA EN CopyFromVpc3 ---\r\n");
+    printf("ERROR: Intento de leer un bloque de %u bytes desde una dirección "
+           "(0x%04X) que excede los límites de la RAM (0x%04X).\r\n",
+           wLength, (unsigned int)addr, ram_limit);
+    printf("Esta es una condición FATAL que probablemente cause un crash. La "
+           "operación de copia será OMITIDA.\r\n");
+    printf("--- FIN LECTURA ILEGAL ---\r\n");
+    // Opcional: llenar el buffer local con un patrón de error para que sea
+    // obvio en el debug
+    memset(pLocalMemory, 0xDE, wLength); // 0xDE for 'dead' or 'deleted'
+    return; // Detener la ejecución para prevenir el crash del SPI
+  }
+  // --- Fin de la Verificación ---
+
+  const uint16_t MAX_TRANSFER_SIZE =
+      240; // Tamaño máximo seguro para transferencias SPI
+  uint16_t remaining = wLength;
+  uint16_t offset = 0;
+
+  // --- NUEVAS LÍNEAS DE DEBUG ---
+  // printf("DEBUG: [CopyFromVpc3] Lectura de 0x%04X, longitud %d\r\n",
+  // (unsigned int)addr, wLength);
+  // -----------------------------
+
+  while (remaining > 0) {
+    uint16_t transferSize =
+        (remaining > MAX_TRANSFER_SIZE) ? MAX_TRANSFER_SIZE : remaining;
+    uint8_t cmd[3] = {OPC_RD_ARRAY, (uint8_t)((addr + offset) >> 8),
+                      (uint8_t)(addr + offset)};
 
     DpAppl_DisableInterruptVPC3Channel1();
     VPC3_CS_LOW();
     HAL_SPI_Transmit(&hspi1, cmd, 3, VPC3_TIMEOUT_MS);
-    HAL_StatusTypeDef status = HAL_SPI_Receive(&hspi1, dst_local, len, VPC3_TIMEOUT_MS);
+    HAL_SPI_Receive(&hspi1, (uint8_t *)pLocalMemory + offset, transferSize,
+                    VPC3_TIMEOUT_MS);
     VPC3_CS_HIGH();
     DpAppl_EnableInterruptVPC3Channel1();
 
-    return (status == HAL_OK) ? VPC3_OK : VPC3_ERROR_SPI_DATA;
-}
-
-/**
- * @brief Escribe un array de bytes en el VPC3+. Esta función es llamada por el macro CopyToVpc3.
- */
-void CopyToVpc3(VPC3_UNSIGNED8_PTR pToVpc3Memory, MEM_UNSIGNED8_PTR pLocalMemory, uint16_t wLength) {
-    const uint16_t MAX_TRANSFER_SIZE = 240; // Tamaño máximo seguro para transferencias SPI
-    VPC3_ADR addr = (VPC3_ADR)(uintptr_t)pToVpc3Memory;
-    
-    uint16_t remaining = wLength;
-    uint16_t offset = 0;
-    
-    while (remaining > 0) {
-        uint16_t transferSize = (remaining > MAX_TRANSFER_SIZE) ? MAX_TRANSFER_SIZE : remaining;
-        uint8_t cmd[3] = {OPC_WR_ARRAY, (uint8_t)((addr + offset) >> 8), (uint8_t)(addr + offset)};
-
-        DpAppl_DisableInterruptVPC3Channel1();
-        VPC3_CS_LOW();
-        HAL_SPI_Transmit(&hspi1, cmd, 3, VPC3_TIMEOUT_MS);
-        HAL_SPI_Transmit(&hspi1, (uint8_t*)pLocalMemory + offset, transferSize, VPC3_TIMEOUT_MS);
-        VPC3_CS_HIGH();
-        DpAppl_EnableInterruptVPC3Channel1();
-        
-        offset += transferSize;
-        remaining -= transferSize;
-    }
-}
-
-/**
- * @brief Lee un array de bytes del VPC3+. Esta es llamada por el macro CopyFromVpc3.
- */
-void CopyFromVpc3(MEM_UNSIGNED8_PTR pLocalMemory, VPC3_UNSIGNED8_PTR pToVpc3Memory, uint16_t wLength) {
-    VPC3_ADR addr = (VPC3_ADR)(uintptr_t)pToVpc3Memory;
-
-    // --- Programación Defensiva: Verificación de Límites Conservativa ---
-    uint16_t ram_limit = ASIC_RAM_LENGTH;
-    if ( (addr + wLength) > ram_limit ) {
-        printf("\r\n--- LECTURA ILEGAL DETECTADA EN CopyFromVpc3 ---\r\n");
-        printf("ERROR: Intento de leer un bloque de %u bytes desde una dirección (0x%04X) que excede los límites de la RAM (0x%04X).\r\n",
-               wLength, (unsigned int)addr, ram_limit);
-        printf("Esta es una condición FATAL que probablemente cause un crash. La operación de copia será OMITIDA.\r\n");
-        printf("--- FIN LECTURA ILEGAL ---\r\n");
-        // Opcional: llenar el buffer local con un patrón de error para que sea obvio en el debug
-        memset(pLocalMemory, 0xDE, wLength); // 0xDE for 'dead' or 'deleted'
-        return; // Detener la ejecución para prevenir el crash del SPI
-    }
-    // --- Fin de la Verificación ---
-
-    const uint16_t MAX_TRANSFER_SIZE = 240; // Tamaño máximo seguro para transferencias SPI
-    uint16_t remaining = wLength;
-    uint16_t offset = 0;
-    
-    // --- NUEVAS LÍNEAS DE DEBUG ---
-    //printf("DEBUG: [CopyFromVpc3] Lectura de 0x%04X, longitud %d\r\n", (unsigned int)addr, wLength);
-    // -----------------------------
-
-    while (remaining > 0) {
-        uint16_t transferSize = (remaining > MAX_TRANSFER_SIZE) ? MAX_TRANSFER_SIZE : remaining;
-        uint8_t cmd[3] = {OPC_RD_ARRAY, (uint8_t)((addr + offset) >> 8), (uint8_t)(addr + offset)};
-
-        DpAppl_DisableInterruptVPC3Channel1();
-        VPC3_CS_LOW();
-        HAL_SPI_Transmit(&hspi1, cmd, 3, VPC3_TIMEOUT_MS);
-        HAL_SPI_Receive(&hspi1, (uint8_t*)pLocalMemory + offset, transferSize, VPC3_TIMEOUT_MS);
-        VPC3_CS_HIGH();
-        DpAppl_EnableInterruptVPC3Channel1();
-        
-        offset += transferSize;
-        remaining -= transferSize;
-    }
-    // --- NUEVAS LÍNEAS DE DEBUG ---
-    //printf("DEBUG: [CopyFromVpc3] Datos leídos: ");
-    //for(int k=0; k<wLength; k++) {
-    //    printf("0x%02X ", ((uint8_t*)pLocalMemory)[k]);
-    //}
-    //printf("\r\n");
-    // -----------------------------
+    offset += transferSize;
+    remaining -= transferSize;
+  }
+  // --- NUEVAS LÍNEAS DE DEBUG ---
+  // printf("DEBUG: [CopyFromVpc3] Datos leídos: ");
+  // for(int k=0; k<wLength; k++) {
+  //    printf("0x%02X ", ((uint8_t*)pLocalMemory)[k]);
+  //}
+  // printf("\r\n");
+  // -----------------------------
 }
 
 /**
  * @brief Llena una sección de memoria del VPC3+ con un valor.
  */
 void Vpc3MemSet(VPC3_ADR wAddress, uint8_t bValue, uint16_t wLength) {
-    const uint16_t BLOCK_SIZE = 256; // Tamaño de bloque para transferencias grandes
-    uint8_t buffer[BLOCK_SIZE];
-    
-    // Llenar el buffer con el valor deseado
-    memset(buffer, bValue, BLOCK_SIZE);
-    
-    // Procesar en bloques
-    uint16_t remaining = wLength;
-    VPC3_ADR currentAddr = wAddress;
-    
-    while (remaining > 0) {
-        uint16_t blockSize = (remaining > BLOCK_SIZE) ? BLOCK_SIZE : remaining;
-        CopyToVpc3((VPC3_UNSIGNED8_PTR)(uintptr_t)currentAddr, buffer, blockSize);
-        
-        currentAddr += blockSize;
-        remaining -= blockSize;
-    }
+  const uint16_t BLOCK_SIZE =
+      256; // Tamaño de bloque para transferencias grandes
+  uint8_t buffer[BLOCK_SIZE];
+
+  // Llenar el buffer con el valor deseado
+  memset(buffer, bValue, BLOCK_SIZE);
+
+  // Procesar en bloques
+  uint16_t remaining = wLength;
+  VPC3_ADR currentAddr = wAddress;
+
+  while (remaining > 0) {
+    uint16_t blockSize = (remaining > BLOCK_SIZE) ? BLOCK_SIZE : remaining;
+    CopyToVpc3((VPC3_UNSIGNED8_PTR)(uintptr_t)currentAddr, buffer, blockSize);
+
+    currentAddr += blockSize;
+    remaining -= blockSize;
+  }
 }
 
 /**
- * @brief Compara dos bloques de memoria del VPC3+. La librería espera que devuelva 0 si son iguales.
+ * @brief Compara dos bloques de memoria del VPC3+. La librería espera que
+ * devuelva 0 si son iguales.
  */
-uint8_t Vpc3MemCmp(VPC3_UNSIGNED8_PTR pToVpc3Memory1, VPC3_UNSIGNED8_PTR pToVpc3Memory2, uint16_t wLength) {
-    uint8_t buffer1[256];
-    uint8_t buffer2[256];
+uint8_t Vpc3MemCmp(VPC3_UNSIGNED8_PTR pToVpc3Memory1,
+                   VPC3_UNSIGNED8_PTR pToVpc3Memory2, uint16_t wLength) {
+  uint8_t buffer1[256];
+  uint8_t buffer2[256];
 
-    if (wLength > sizeof(buffer1)) {
-        wLength = sizeof(buffer1); // Limitar para evitar desbordamiento del stack
-    }
+  if (wLength > sizeof(buffer1)) {
+    wLength = sizeof(buffer1); // Limitar para evitar desbordamiento del stack
+  }
 
-    // Lee ambos bloques a la memoria local y luego compara
-    CopyFromVpc3(buffer1, pToVpc3Memory1, wLength);
-    CopyFromVpc3(buffer2, pToVpc3Memory2, wLength);
+  // Lee ambos bloques a la memoria local y luego compara
+  CopyFromVpc3(buffer1, pToVpc3Memory1, wLength);
+  CopyFromVpc3(buffer2, pToVpc3Memory2, wLength);
 
-    return (uint8_t)memcmp(buffer1, buffer2, wLength);
+  return (uint8_t)memcmp(buffer1, buffer2, wLength);
 }
-


### PR DESCRIPTION
## Summary
- use dp_if.h macros for VPC3+S register dump
- correct Vpc3Write MODE_REG_3 logging and show MinTsdrVal writes separately

------
