### PR TITLE
Check diag buffer and state before updating diagnosis

### DIFF
--- a/Core/Src/dp_if.c
+++ b/Core/Src/dp_if.c
@@ -2736,9 +2736,26 @@ uint8_t           bDpState;
 
          if( bRetValue == DP_OK )
          {
-            printf("DEBUG: [VPC3_SetDiagnosis] Llamando VPC3_UpdateDiagnosis...\n");
-            pDpSystem->pDiagBuffer = VPC3_UpdateDiagnosis( bDiagControl, pbToUserDiagData, bUserDiagLength );
-            printf("DEBUG: [VPC3_SetDiagnosis] VPC3_UpdateDiagnosis completado\n");
+            printf("DEBUG: [VPC3_SetDiagnosis] Verificando pDiagBuffer y estado DP...\n");
+            if( pDpSystem->pDiagBuffer != VPC3_NULL_PTR )
+            {
+               if( VPC3_GET_DP_STATE() != WAIT_PRM )
+               {
+                  printf("DEBUG: [VPC3_SetDiagnosis] Llamando VPC3_UpdateDiagnosis...\n");
+                  pDpSystem->pDiagBuffer = VPC3_UpdateDiagnosis( bDiagControl, pbToUserDiagData, bUserDiagLength );
+                  printf("DEBUG: [VPC3_SetDiagnosis] VPC3_UpdateDiagnosis completado\n");
+               }
+               else
+               {
+                  printf("DEBUG: [VPC3_SetDiagnosis] ERROR: Estado WAIT_PRM, no se actualiza diagnóstico\n");
+                  bRetValue = DP_DIAG_SEQUENCE_ERROR;
+               }
+            }
+            else
+            {
+               printf("DEBUG: [VPC3_SetDiagnosis] ERROR: pDiagBuffer es NULL\n");
+               bRetValue = DP_DIAG_NO_BUFFER_ERROR;
+            }
          } /* if( bRetValue == DP_OK ) */
       } /* if( bRetValue == DP_OK ) */
    } /* if( VPC3_CheckDiagBufPtr() != VPC3_NULL_PTR ) */


### PR DESCRIPTION
## Summary
- validate diagnosis buffer pointer and DP state before updating diagnosis to avoid writes in WAIT_PRM

## Testing
- `make` *(fails: No targets specified and no makefile found)*
- `gcc -c Core/Src/dp_if.c -I Core/Inc` *(fails: stm32f4xx_hal.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cab71cc4832eb5004f5f5d22d3a7