### PR TITLE
Log 0x0800 flag after reading wPollInterruptEvent

### DIFF
--- a/Core/Src/dp_isr.c
+++ b/Core/Src/dp_isr.c
@@ -143,11 +143,12 @@ volatile uint8_t bResult;
       #endif /* #if VPC3_SERIAL_MODE */
 
       // Log para verificar la máscara de software (usando ring buffer)
-      ISR_LOG_VAL("[VPC3_Poll]", "Eventos hardware leidos", pDpSystem->wPollInterruptEvent);
-      ISR_LOG_VAL("[VPC3_Poll]", "Mascara de software aplicada", pDpSystem->wPollInterruptMask);
-      
-      // Decodificar eventos específicos para análisis (sin printf)
       uint16_t events = pDpSystem->wPollInterruptEvent;
+      ISR_LOG_VAL("[VPC3_Poll]", "Eventos hardware leidos", events);
+      ISR_LOG("[VPC3_Poll]", (events & 0x0800) ? "events & 0x0800 activo" : "events & 0x0800 inactivo");
+      ISR_LOG_VAL("[VPC3_Poll]", "Mascara de software aplicada", pDpSystem->wPollInterruptMask);
+
+      // Decodificar eventos específicos para análisis (sin printf)
       if (events & 0x0001) ISR_LOG("[VPC3_Poll]", "MAC_RESET/CLOCK_SYNC (0x0001)");
       if (events & 0x0002) ISR_LOG("[VPC3_Poll]", "GO_LEAVE_DATA_EX (0x0002)");
       if (events & 0x0004) ISR_LOG("[VPC3_Poll]", "BAUDRATE_DETECT (0x0004)");


### PR DESCRIPTION
## Summary
- Log whether NEW_PRM_DATA (0x0800) is set immediately after reading `wPollInterruptEvent`

## Testing
- ⚠️ `gcc -fsyntax-only -I Core/Inc Core/Src/dp_isr.c` *(fails: stm32f4xx_hal.h missing in container)*

------
https://chatgpt.com/codex/tasks/task_e_68b5cd8a9210832ea30c4a64c957d068